### PR TITLE
AlgoPoaP - Proof of Attendance Protocol on Algorand

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Algorand is an open-source, proof of stake blockchain and smart contract computi
 - [Algocurator](https://www.algocurator.com/home) - The Biggest Unofficial One-Stop Hub for Algorand.
 - [genpyteal](https://github.com/runvnc/genpyteal) - Generate PyTeal from (mostly) normal Python.
 - [AgorHash](https://github.com/bafio89/agorhash) - Public, permissionless, decentralized and uncensorable free speech protocol.
+- [AlgoPoaP](https://github.com/AlgoPoaP) - Proof of Attendance Protocol (and much more) on Algorand.
 - [QRCode Generator](https://github.com/emg110/algorand-qrcode)
 - [algofractals](https://github.com/aorumbayev/algofractals) - Mint randomly generated mandelbrot fractals with embedded ARC69 tags.
 - [algorewards](https://algorewards.github.io/) - Free and unofficial Algorand governance reward calculator. Hosted on GitHub Pages.


### PR DESCRIPTION
Pull request:
AlgoPoaP is a comprehensive and featureful Proof of Attendance Protocol (soon Proof of Anything) on the Algorand blockchain.

