### PR TITLE
Add CorvidLabs Swift/iOS tools for Algorand

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,11 @@ Algorand is an open-source, proof of stake Blockchain and smart contract computi
 
 - [algorand-wallet](https://github.com/algorand/algorand-wallet) - Algorand wallet official implementation in Swift.
 - [swift-algorand-sdk](https://github.com/Jesulonimi21/Swift-Algorand-Sdk) - A Swift SDK for interacting with the Algorand Blockchain.
+- [swift-algorand](https://github.com/CorvidLabs/swift-algorand) - Modern Swift SDK for the Algorand blockchain with async/await support.
+- [swift-algokit](https://github.com/CorvidLabs/swift-algokit) - AlgoKit utilities for Swift developers.
+- [swift-arc](https://github.com/CorvidLabs/swift-arc) - Swift library for working with Algorand ARC metadata standards for NFTs.
+- [swift-mint](https://github.com/CorvidLabs/swift-mint) - Swift library for minting NFTs on the Algorand blockchain.
+- [swift-algochat](https://github.com/CorvidLabs/swift-algochat) - End-to-end encrypted messaging on Algorand with hybrid ECDH and PSK ratcheting in Swift.
 
 #### Ruby
 
@@ -316,6 +321,7 @@ Algorand is an open-source, proof of stake Blockchain and smart contract computi
 - [irulan](https://irulan.dev/) - Web app for deploying + testing smart contracts ([open source! + PRs welcome](https://github.com/thencc/irulan)).
 - [algojig](https://github.com/Hipo/algojig) - A tool for testing Algorand smart contracts.
 - [tealinspector](https://github.com/Hipo/tealinspector) - Quick and easy TEAL code debugging by Hipo labs.
+- [swift-algotest](https://github.com/CorvidLabs/swift-algotest) - Swift testing framework for Algorand smart contracts with mock chain support.
 
 
 ### Deployment & Environment

--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ Algorand is an open-source, proof of stake Blockchain and smart contract computi
 
 - [algorand-wallet](https://github.com/algorand/algorand-wallet) - Algorand wallet official implementation in Swift.
 - [swift-algorand-sdk](https://github.com/Jesulonimi21/Swift-Algorand-Sdk) - A Swift SDK for interacting with the Algorand Blockchain.
-- [swift-algorand](https://github.com/CorvidLabs/swift-algorand) - Modern Swift SDK for the Algorand blockchain with async/await support.
+- [swift-algorand](https://github.com/CorvidLabs/swift-algorand) - Modern Swift SDK for the Algorand Blockchain with async/await support.
 - [swift-algokit](https://github.com/CorvidLabs/swift-algokit) - AlgoKit utilities for Swift developers.
 - [swift-arc](https://github.com/CorvidLabs/swift-arc) - Swift library for working with Algorand ARC metadata standards for NFTs.
-- [swift-mint](https://github.com/CorvidLabs/swift-mint) - Swift library for minting NFTs on the Algorand blockchain.
+- [swift-mint](https://github.com/CorvidLabs/swift-mint) - Swift library for minting NFTs on the Algorand Blockchain.
 - [swift-algochat](https://github.com/CorvidLabs/swift-algochat) - End-to-end encrypted messaging on Algorand with hybrid ECDH and PSK ratcheting in Swift.
 
 #### Ruby


### PR DESCRIPTION
## Summary

- Adds 5 Swift libraries from [CorvidLabs](https://github.com/CorvidLabs) to the **Swift** SDK section: `swift-algorand`, `swift-algokit`, `swift-arc`, `swift-mint`, and `swift-algochat`
- Adds `swift-algotest` to the **Testing & Debugging** section
- Expands Algorand's iOS/macOS developer tooling coverage, which currently has only 2 entries in the Swift section

## Added entries

| Package | Section | Description |
|---------|---------|-------------|
| [swift-algorand](https://github.com/CorvidLabs/swift-algorand) | Swift SDKs | Modern async/await Algorand SDK |
| [swift-algokit](https://github.com/CorvidLabs/swift-algokit) | Swift SDKs | AlgoKit utilities for Swift |
| [swift-arc](https://github.com/CorvidLabs/swift-arc) | Swift SDKs | ARC metadata standards library |
| [swift-mint](https://github.com/CorvidLabs/swift-mint) | Swift SDKs | NFT minting library |
| [swift-algochat](https://github.com/CorvidLabs/swift-algochat) | Swift SDKs | Encrypted on-chain messaging |
| [swift-algotest](https://github.com/CorvidLabs/swift-algotest) | Testing & Debugging | Mock chain testing framework |

## Checklist

- [x] Searched for duplicates — none of these packages are currently listed
- [x] All packages are public, documented, and tested
- [x] Follows the `[PACKAGE](LINK) - DESCRIPTION.` format
- [x] Descriptions end with a period
- [x] Spelling and grammar checked
- [x] No trailing whitespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)