### PR TITLE
Add DorkFi to DeFi Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ Algorand is an open-source, proof of stake Blockchain and smart contract computi
 - [vestige.fi](https://vestige.fi/) - A decentralized ecosystem of tools primary used as a tool to track and trend Algorand Standard Assets and Liquidity Pools across the ecosystem. The platform also provides a decentralized swap and a launchpad platform.
 - [folks-router](https://github.com/Folks-Finance/folks-router) - Efficient swap routing SDK on Algorand by Folks Finance.
 - [Folks-Finance/algorand-js-sdk](https://github.com/Folks-Finance/folks-finance-js-sdk) - Official Folks Finance Algorand Protocol SDK.
+- [DorkFi](https://dork.fi/) - Cross-chain borrow/lend protocol on Algorand and Voi Network. Features overcollateralized lending, WAD stablecoin minting, and UNIT governance token.
 
 
 ### NFT Marketplaces


### PR DESCRIPTION
Adds [DorkFi](https://dork.fi) — a cross-chain borrow/lend protocol on Algorand and Voi Network.\n\n- Overcollateralized lending markets\n- WAD stablecoin (mintable via collateral)\n- UNIT governance token (fixed supply 420,069)\n- Live on Algorand mainnet (App ID: 3207735602) and Voi Network\n- Twitter: https://x.com/dork_fi